### PR TITLE
Fix for: Doesn't compile on Linux 3.2

### DIFF
--- a/nvidiabl-models.c
+++ b/nvidiabl-models.c
@@ -13,6 +13,7 @@
  * (at your option) any later version.
  */
 
+#include <linux/moduleparam.h>
 #include "nvidiabl-models.h"
 
 /* Register constants */


### PR DESCRIPTION
Hello.

Here is a simple fix for compilation with Linux 3.2 kernels.

Issue details: https://github.com/guillaumezin/nvidiabl/issues/27
