### PR TITLE
Issue 47: Add 'type' parameter to support gnome-settings-daemon

### DIFF
--- a/nvidiabl-module.c
+++ b/nvidiabl-module.c
@@ -50,8 +50,8 @@ static unsigned long pci_id = PCI_ANY_ID;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39)
 /*
- * first element of bl_type will receive the user's module parameter
- * which will be matched against the other elements. Their indexes match the definitions
+ * bl_type will receive the user's module parameter which will be matched against
+ * the bl_types[] elements. Their indexes match the definitions
  * of 'enum backlight_type' in linux/backlight.h, making translating string into
  * enum value easy to do.
  */


### PR DESCRIPTION
```
gnome-settings-daemon prefers backlight devices in the order:

firmware
platform
raw

By default 'nvidiabl' sets itself to 'raw'. Adding this module option allows the
user to configure the type so as to have nvidiabl chosen in preference to other
backlight drivers (such as ACPI platform drivers).

To use it, add the option "type=?" to the module options replacing '?' with one
of the types listed above. E.g:

options nvidiabl type=firmware

or:

sudo modprobe nvidiabl type=firmware

Signed-off-by: TJ <linux@iam.tj>
```
