### PR TITLE
exclude /install dirs from github source export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/install export-ignore


### PR DESCRIPTION
this decreases github release tarball size drastically

currently each release the size grows, as you seem to store .deb and sourcecode of previous releases in github repo:
https://github.com/guillaumezin/nvidiabl/tree/v0.87/install

imho you shouldn't store them there, the source only tarball can be obtained from github releases page:
https://github.com/guillaumezin/nvidiabl/releases

also the install/tarball/*source-only* contain recursively previous releases (pff!)

anyway, this PR will exclude the /install dir from github generated tarballs:
before:
https://github.com/guillaumezin/nvidiabl/archive/v0.87.tar.gz (35mb)
after this pr:
https://github.com/glensc/nvidiabl/archive/tarball-size.tar.gz (15k)